### PR TITLE
Add schema for Project Citations and Source lookup tables

### DIFF
--- a/01_database_build/02_Metadata.sql
+++ b/01_database_build/02_Metadata.sql
@@ -1,0 +1,290 @@
+-- -*- coding: utf-8 -*-
+-- ---------------------------------------------------------------------------
+-- Build metadata and constraint tables
+-- Author: Timm Nawrocki, Alaska Center for Conservation Science
+-- Last Updated: 2026-03-27
+-- Usage: Script should be executed in a PostgreSQL 17+ database.
+-- Description: "Build metadata and constraint tables" creates the empty tables for the metadata components of the AKVEG database, including the schema and data dictionary. WARNING: THIS SCRIPT WILL ERASE ALL DATA IN EXISTING METADATA TABLES.
+-- ---------------------------------------------------------------------------
+
+-- Initialize transaction
+START TRANSACTION;
+
+-- Drop metadata tables if they exist
+DROP TABLE IF EXISTS
+    completion,
+    cover_method,
+    cover_type,
+    crown_class,
+    data_tier,
+    data_type,
+    database_dictionary,
+    database_schema,
+    disturbance,
+    disturbance_severity,
+    drainage,
+    geomorphology,
+    ground_element,
+    h_datum,
+    height_type,
+    location_type,
+    macrotopography,
+    microtopography,
+    moisture,
+    organization,
+    organization_type,
+    personnel,
+    perspective,
+    physiography,
+    plot_dimensions,
+    positional_accuracy,
+    restrictive_type,
+    schema_category,
+    schema_table,
+    scope,
+    shrub_class,
+    soil_class,
+    soil_nonmatrix_features,
+    soil_structure,
+    soil_texture,
+    soil_horizon_type,
+    soil_horizon_suffix,
+    soil_hue,
+    source_collection,
+    source_type,
+    structural_class,
+    structural_group
+CASCADE;
+
+-- Create constraint tables
+
+CREATE TABLE completion (
+    completion_id smallint PRIMARY KEY,
+    completion varchar(30) UNIQUE NOT NULL
+);
+
+CREATE TABLE cover_method (
+    cover_method_id smallint PRIMARY KEY,
+    cover_method varchar(50) UNIQUE NOT NULL
+);
+
+CREATE TABLE cover_type (
+    cover_type_id smallint PRIMARY KEY,
+    cover_type varchar(50) UNIQUE NOT NULL
+);
+
+CREATE TABLE crown_class (
+    crown_class_id smallint PRIMARY KEY,
+    crown_class varchar(30) UNIQUE NOT NULL
+);
+
+CREATE TABLE data_tier (
+    data_tier_id smallint PRIMARY KEY,
+    data_tier varchar(30) UNIQUE NOT NULL
+);
+
+CREATE TABLE data_type (
+    data_type_id smallint PRIMARY KEY,
+    data_type varchar(80) UNIQUE NOT NULL
+);
+
+CREATE TABLE disturbance (
+    disturbance_id smallint PRIMARY KEY,
+    disturbance varchar(50) UNIQUE NOT NULL
+);
+
+CREATE TABLE disturbance_severity (
+    disturbance_severity_id smallint PRIMARY KEY,
+    disturbance_severity varchar(20) UNIQUE NOT NULL
+);
+
+CREATE TABLE drainage (
+    drainage_id smallint PRIMARY KEY,
+    drainage varchar(50) UNIQUE NOT NULL
+);
+
+CREATE TABLE geomorphology (
+    geomorphology_id smallint PRIMARY KEY,
+    geomorphology varchar(50) UNIQUE NOT NULL
+);
+
+CREATE TABLE ground_element (
+    ground_element_code varchar(2) PRIMARY KEY,
+    ground_element varchar(50) UNIQUE NOT NULL,
+    element_type varchar(7) NOT NULL
+);
+
+CREATE TABLE h_datum (
+    h_datum_epsg integer PRIMARY KEY,
+    h_datum varchar(20) UNIQUE NOT NULL
+);
+
+CREATE TABLE height_type (
+    height_type_id smallint PRIMARY KEY,
+    height_type varchar(50) UNIQUE NOT NULL
+);
+
+CREATE TABLE location_type (
+    location_type_id smallint PRIMARY KEY,
+    location_type varchar(20) UNIQUE NOT NULL
+);
+
+CREATE TABLE macrotopography (
+    macrotopography_id smallint PRIMARY KEY,
+    macrotopography varchar(50) UNIQUE NOT NULL
+);
+
+CREATE TABLE microtopography (
+    microtopography_id smallint PRIMARY KEY,
+    microtopography varchar(50) UNIQUE NOT NULL
+);
+
+CREATE TABLE moisture (
+    moisture_id smallint PRIMARY KEY,
+    moisture varchar(50) UNIQUE NOT NULL
+);
+
+CREATE TABLE organization_type (
+    organization_type_id smallint PRIMARY KEY,
+    organization_type varchar(50) UNIQUE NOT NULL
+);
+
+CREATE TABLE personnel (
+    personnel_id smallint PRIMARY KEY,
+    personnel varchar(50) UNIQUE NOT NULL
+);
+
+CREATE TABLE perspective (
+    perspective_id smallint PRIMARY KEY,
+    perspective varchar(50) UNIQUE NOT NULL
+);
+
+CREATE TABLE physiography (
+    physiography_id smallint PRIMARY KEY,
+    physiography varchar(30) UNIQUE NOT NULL
+);
+
+CREATE TABLE plot_dimensions (
+    plot_dimensions_id smallint PRIMARY KEY,
+    plot_dimensions_m varchar(20) UNIQUE NOT NULL
+);
+
+CREATE TABLE positional_accuracy (
+    positional_accuracy_id smallint PRIMARY KEY,
+    positional_accuracy varchar(30) UNIQUE NOT NULL
+);
+
+CREATE TABLE restrictive_type (
+    restrictive_type_id smallint PRIMARY KEY,
+    restrictive_type varchar(50) UNIQUE NOT NULL
+);
+
+CREATE TABLE schema_category (
+    schema_category_id smallint PRIMARY KEY,
+    schema_category varchar(80) UNIQUE NOT NULL
+);
+
+CREATE TABLE schema_table (
+    schema_table_id smallint PRIMARY KEY,
+    schema_table varchar(80) UNIQUE NOT NULL
+);
+
+CREATE TABLE scope (
+    scope_id smallint PRIMARY KEY,
+    scope varchar(30) UNIQUE NOT NULL
+);
+
+CREATE TABLE shrub_class (
+    shrub_class_id smallint PRIMARY KEY,
+    shrub_class varchar(20) UNIQUE NOT NULL
+);
+
+CREATE TABLE soil_class (
+    soil_class_id smallint PRIMARY KEY,
+    soil_class varchar(50) UNIQUE NOT NULL
+);
+
+CREATE TABLE soil_nonmatrix_features (
+    nonmatrix_feature_code varchar(2) PRIMARY KEY,
+    nonmatrix_feature varchar(30) UNIQUE NOT NULL
+);
+
+CREATE TABLE soil_structure (
+    soil_structure_code varchar(3) PRIMARY KEY,
+    soil_structure varchar(30) UNIQUE NOT NULL
+);
+
+CREATE TABLE soil_texture (
+    soil_texture_code varchar(4) PRIMARY KEY,
+    soil_texture varchar(50) UNIQUE NOT NULL
+);
+
+CREATE TABLE soil_horizon_type (
+    soil_horizon_type_code varchar(1) PRIMARY KEY,
+    soil_horizon_type varchar(30) UNIQUE NOT NULL
+);
+
+CREATE TABLE soil_horizon_suffix (
+    soil_horizon_suffix_code varchar(2) PRIMARY KEY,
+    soil_horizon_suffix varchar(50) UNIQUE NOT NULL
+);
+
+CREATE TABLE soil_hue (
+    soil_hue_code varchar(5) PRIMARY KEY,
+    soil_hue varchar(5) UNIQUE NOT NULL
+);
+
+CREATE TABLE source_collection (
+    source_collection_id smallint PRIMARY KEY,
+    source_collection varchar(50) UNIQUE NOT NULL
+);
+
+CREATE TABLE source_type (
+    source_type_id smallint PRIMARY KEY,
+    source_type varchar(30) UNIQUE NOT NULL
+);
+
+CREATE TABLE structural_class (
+    structural_class_code varchar(10) PRIMARY KEY,
+    structural_class varchar(50) UNIQUE NOT NULL
+);
+
+CREATE TABLE structural_group (
+    structural_group_id smallint PRIMARY KEY,
+    structural_group varchar(50) UNIQUE NOT NULL
+);
+
+-- Create organization table
+CREATE TABLE organization (
+    organization_id smallint PRIMARY KEY,
+    organization varchar(20) UNIQUE NOT NULL,
+    organization_type_id smallint NOT NULL REFERENCES organization_type
+);
+
+-- Create schema table
+CREATE TABLE database_schema (
+    field_id smallint PRIMARY KEY,
+    standards_section smallint NOT NULL,
+    schema_category_id smallint NOT NULL REFERENCES schema_category,
+    schema_table_id smallint NOT NULL REFERENCES schema_table,
+    field varchar(50) NOT NULL,
+    data_type_id smallint NOT NULL REFERENCES data_type,
+    field_length varchar(10),
+    is_unique boolean NOT NULL,
+    is_key boolean NOT NULL,
+    required boolean NOT NULL,
+    link_table_id smallint REFERENCES schema_table,
+    field_description varchar(2000) NOT NULL
+);
+
+-- Create dictionary table
+CREATE TABLE database_dictionary (
+    dictionary_id integer PRIMARY KEY,
+    field_id smallint NOT NULL REFERENCES database_schema,
+    data_attribute_id varchar(10) NOT NULL,
+    data_attribute varchar(120) NOT NULL,
+    definition varchar(2000) NOT NULL
+);
+
+-- Commit transaction
+COMMIT TRANSACTION;

--- a/01_database_build/03_Project.sql
+++ b/01_database_build/03_Project.sql
@@ -1,0 +1,76 @@
+-- -*- coding: utf-8 -*-
+-- ---------------------------------------------------------------------------
+-- Build project tables
+-- Author: Timm Nawrocki, Alaska Center for Conservation Science
+-- Last Updated: 2026-03-27
+-- Usage: Script should be executed in a PostgreSQL 17+ database.
+-- Description: "Build project tables" creates the empty tables for the vegetation survey and monitoring projects components of the AKVEG database. WARNING: THIS SCRIPT WILL ERASE ALL DATA IN EXISTING PROJECT TABLES.
+-- ---------------------------------------------------------------------------
+
+-- Initialize transaction
+START TRANSACTION;
+
+-- Drop project tables if they exist
+DROP TABLE IF EXISTS
+    project,
+    citations,
+    project_source,
+    project_status,
+    project_citations
+CASCADE;
+
+-- Create projects table
+CREATE TABLE project (
+    project_code varchar(30) PRIMARY KEY,
+    project_name varchar(250) UNIQUE NOT NULL,
+    originator_id smallint NOT NULL REFERENCES organization,
+    funder_id smallint NOT NULL REFERENCES organization,
+    manager_id smallint NOT NULL REFERENCES personnel,
+    completion_id smallint NOT NULL REFERENCES completion,
+    year_start smallint NOT NULL,
+    year_end smallint NOT NULL,
+    project_description varchar(500) NOT NULL,
+    private boolean NOT NULL
+);
+
+-- Create citations table
+CREATE TABLE citations (
+  citation_id smallint PRIMARY KEY,
+  citation_short varchar(50) UNIQUE NOT NULL,
+  citation_long text UNIQUE NOT NULL,
+  citation_url text
+);
+
+-- Create project source table
+CREATE TABLE project_source (
+    project_source_id smallint PRIMARY KEY,
+    project_code varchar(30) NOT NULL REFERENCES project,
+    source_type_id smallint NOT NULL REFERENCES source_type,
+    source_collection_id smallint REFERENCES source_collection,
+    published bool NOT NULL,
+    download_url text,
+    source_contact_id smallint REFERENCES personnel,
+    acquisition_date date NOT NULL
+);
+
+-- Create project status table
+CREATE TABLE project_status (
+    project_status_id smallint PRIMARY KEY,
+    project_code varchar(30) NOT NULL REFERENCES project,
+    project_modified date NOT NULL,
+    site_modified date,
+    vegetation_modified date,
+    abiotic_modified date,
+    environment_modified date,
+    modified_by_id smallint NOT NULL
+);
+
+--- Create project citation junction table
+CREATE TABLE project_citations (
+    project_code varchar(30) NOT NULL REFERENCES project,
+    citation_id smallint NOT NULL REFERENCES citations,
+    PRIMARY KEY (project_code, citation_id)
+);
+
+-- Commit transaction
+COMMIT TRANSACTION;


### PR DESCRIPTION
## Description

This PR creates the schema for five new tables required to track project provenance (source) and associated citations. These changes are part of the ongoing work for Issue #18.

Note: I temporarily deleted these SQL files from the main branch to prevent a merge conflict. This PR re-introduces `02_Metadata.sql` and `03_Project.sql` as "new" files, but they do not make any changes to the schema of existing tables.

## Key Changes

Create the following tables to support the project citations feature:

- source_type: Lookup table to store constrained values about the type of source for project data.
- source_collection: Lookup table to store constrained values about the name of the collection the dataset belongs to.
- citations: Stores bibliographic information for citations.
- project_source: Stores information on the provenance of project data. 
- project_citations: Junction table linking project code to citations.

The schema design (including data types and foreign key constraints) follows the structure outlined in [this comment in Issue #18](https://github.com/akveg-map/akveg-database/issues/18#issuecomment-3938105980). This schema ensures that project metadata can be traced back to its original source, while allowing for a many-to-many relationship between projects and bibliographic references.

## Next Steps

- Develop R-side logic to ingest data into these specific tables.